### PR TITLE
Add Azure OpenAI provider support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,16 @@
-# Deep Research Assistant - Environment Variables
+# --- Provider selection ---
+# openai (default) | azure
+PROVIDER=openai
 
-# Backend Server Configuration
-SERVER_HOST=0.0.0.0
-SERVER_PORT=8123
-
-# Frontend → Backend Connection
-LANGGRAPH_DEPLOYMENT_URL=http://localhost:8123
-
-# OpenAI API (https://platform.openai.com/api-keys)
-OPENAI_API_KEY=sk-...
+# --- OpenAI (PROVIDER=openai) ---
+OPENAI_API_KEY=
 OPENAI_MODEL=gpt-5.2
 
-# Tavily API (https://app.tavily.com/)
-TAVILY_API_KEY=tvly-...
+# --- Azure OpenAI (PROVIDER=azure) ---
+AZURE_OPENAI_API_KEY=
+AZURE_OPENAI_ENDPOINT=https://your-resource-name.openai.azure.com
+AZURE_OPENAI_DEPLOYMENT=
+AZURE_OPENAI_API_VERSION=2024-10-21
+
+# --- Research tool ---
+TAVILY_API_KEY=

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -6,11 +6,12 @@ planning, filesystem, and subagent capabilities using Tavily for web research.
 """
 
 import os
-from dotenv import load_dotenv
-from langchain_openai import ChatOpenAI
-from deepagents import create_deep_agent
-from langgraph.checkpoint.memory import MemorySaver
+
 from copilotkit import CopilotKitMiddleware
+from deepagents import create_deep_agent
+from dotenv import load_dotenv
+from langchain_openai import AzureChatOpenAI, ChatOpenAI
+from langgraph.checkpoint.memory import MemorySaver
 
 from tools import research
 
@@ -56,22 +57,59 @@ def build_agent():
     Returns:
         Compiled LangGraph StateGraph configured for research tasks
     """
-    api_key = os.environ.get("OPENAI_API_KEY")
-    if not api_key:
-        raise RuntimeError("Missing OPENAI_API_KEY environment variable")
+
+    provider = os.environ.get("PROVIDER", "openai").lower().strip()
+    if provider not in {"openai", "azure"}:
+        raise RuntimeError(f"Invalid PROVIDER='{provider}'. Expected 'openai' or 'azure'.")
+
+    if provider == "azure":
+        azure_api_key = os.environ.get("AZURE_OPENAI_API_KEY")
+        azure_endpoint = os.environ.get("AZURE_OPENAI_ENDPOINT")
+        azure_deployment = os.environ.get("AZURE_OPENAI_DEPLOYMENT")
+        azure_api_version = os.environ.get("AZURE_OPENAI_API_VERSION", "2024-10-21")
+
+        missing = [
+            name
+            for name, val in {
+                "AZURE_OPENAI_API_KEY": azure_api_key,
+                "AZURE_OPENAI_ENDPOINT": azure_endpoint,
+                "AZURE_OPENAI_DEPLOYMENT": azure_deployment,
+            }.items()
+            if not val
+        ]
+        if missing:
+            raise RuntimeError(
+                "Missing required Azure OpenAI environment variables: " + ", ".join(missing)
+            )
+    else:
+        api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError("Missing OPENAI_API_KEY environment variable")
 
     # Check for Tavily API key
     tavily_key = os.environ.get("TAVILY_API_KEY")
     if not tavily_key:
         raise RuntimeError("Missing TAVILY_API_KEY environment variable")
 
-    # Initialize LLM - use model from env or default to gpt-5.2
-    model_name = os.environ.get("OPENAI_MODEL", "gpt-5.2")
-    llm = ChatOpenAI(
-        model=model_name,
-        temperature=0.7,
-        api_key=api_key,
-    )
+    # Initialize LLM
+    # - OpenAI: OPENAI_MODEL (default: gpt-5.2)
+    # - Azure: AZURE_OPENAI_DEPLOYMENT is the model/deployment identifier
+    if provider == "azure":
+        model_name = azure_deployment
+        llm = AzureChatOpenAI(
+            azure_deployment=azure_deployment,
+            azure_endpoint=azure_endpoint,
+            api_version=azure_api_version,
+            api_key=azure_api_key,
+            temperature=0.7,
+        )
+    else:
+        model_name = os.environ.get("OPENAI_MODEL", "gpt-5.2")
+        llm = ChatOpenAI(
+            model=model_name,
+            temperature=0.7,
+            api_key=api_key,
+        )
 
     # Main agent gets research tool plus built-in Deep Agents tools
     # (write_todos, read_file, write_file)
@@ -89,7 +127,7 @@ def build_agent():
         checkpointer=MemorySaver(),
     )
 
-    print(f"[AGENT] Deep Research Agent created with model={model_name}")
+    print(f"[AGENT] Deep Research Agent created with provider={provider} model={model_name}")
     print(f"[AGENT] Main tools: {[t.name for t in main_tools]}")
 
     # Configure recursion limit for complex research tasks

--- a/agent/pyproject.toml
+++ b/agent/pyproject.toml
@@ -18,3 +18,8 @@ dependencies = [
 [tool.setuptools]
 py-modules = ["agent", "main", "tools"]
 
+
+[tool.uv]
+dev-dependencies = [
+    "pytest>=8.0.0",
+]

--- a/agent/test_provider_config.py
+++ b/agent/test_provider_config.py
@@ -1,0 +1,42 @@
+import os
+import types
+import importlib
+
+
+def _reload_agent_module():
+    # Ensure env changes apply
+    if 'agent.agent' in importlib.sys.modules:
+        del importlib.sys.modules['agent.agent']
+    return importlib.import_module('agent.agent')
+
+
+def test_provider_openai_missing_key_raises(monkeypatch):
+    monkeypatch.setenv('PROVIDER', 'openai')
+    monkeypatch.delenv('OPENAI_API_KEY', raising=False)
+    monkeypatch.setenv('TAVILY_API_KEY', 'x')
+
+    mod = _reload_agent_module()
+    try:
+        mod.build_agent()
+    except RuntimeError as e:
+        assert 'OPENAI_API_KEY' in str(e)
+    else:
+        raise AssertionError('Expected RuntimeError')
+
+
+def test_provider_azure_missing_vars_raises(monkeypatch):
+    monkeypatch.setenv('PROVIDER', 'azure')
+    monkeypatch.setenv('TAVILY_API_KEY', 'x')
+    for k in ['AZURE_OPENAI_API_KEY', 'AZURE_OPENAI_ENDPOINT', 'AZURE_OPENAI_DEPLOYMENT']:
+        monkeypatch.delenv(k, raising=False)
+
+    mod = _reload_agent_module()
+    try:
+        mod.build_agent()
+    except RuntimeError as e:
+        s = str(e)
+        assert 'AZURE_OPENAI_API_KEY' in s
+        assert 'AZURE_OPENAI_ENDPOINT' in s
+        assert 'AZURE_OPENAI_DEPLOYMENT' in s
+    else:
+        raise AssertionError('Expected RuntimeError')


### PR DESCRIPTION
Closes #4.

Changes:
- Add PROVIDER env var (openai|azure)
- Support Azure OpenAI env vars: AZURE_OPENAI_API_KEY, AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_DEPLOYMENT, AZURE_OPENAI_API_VERSION (default 2024-10-21)
- Update agent to use AzureChatOpenAI when PROVIDER=azure
- Document new env vars in .env.example
- Add small config validation tests (pytest)