### PR TITLE
Support AGENT_MODE for research vs coding agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,9 @@
-# Deep Research Assistant - Environment Variables
+# Deep Agents Demo - Environment Variables
+
+# Agent mode
+# - research: research assistant behavior (requires TAVILY_API_KEY)
+# - coding: coding agent behavior (enables shell/filesystem tools)
+AGENT_MODE=research
 
 # Backend Server Configuration
 SERVER_HOST=0.0.0.0
@@ -11,5 +16,6 @@ LANGGRAPH_DEPLOYMENT_URL=http://localhost:8123
 OPENAI_API_KEY=sk-...
 OPENAI_MODEL=gpt-5.2
 
-# Tavily API (https://app.tavily.com/)
+# Tavily API (required only for AGENT_MODE=research)
+# https://app.tavily.com/
 TAVILY_API_KEY=tvly-...

--- a/README.md
+++ b/README.md
@@ -64,8 +64,9 @@ deep-research-v2/
 
 | Variable                   | Required | Default                 | Description                                         |
 | -------------------------- | -------- | ----------------------- | --------------------------------------------------- |
-| `OPENAI_API_KEY`           | Yes      | -                       | [Get API key](https://platform.openai.com/api-keys) |
-| `TAVILY_API_KEY`           | Yes      | -                       | [Get API key](https://app.tavily.com/home)          |
+| `OPENAI_API_KEY`           | Yes      | -                       | OpenAI API key                                      |
+| `AGENT_MODE`              | No       | `research`              | Agent mode: research or coding                      |
+| `TAVILY_API_KEY`           | Research-only | -                       | Tavily API key (required in AGENT_MODE=research)    |
 | `OPENAI_MODEL`             | No       | `gpt-5.2`               | Model to use (gpt-5.2, gpt-5, etc.)                 |
 | `LANGGRAPH_DEPLOYMENT_URL` | No       | `http://localhost:8123` | Backend URL                                         |
 | `SERVER_HOST`              | No       | `0.0.0.0`               | Backend host                                        |

--- a/agent/agent.py
+++ b/agent/agent.py
@@ -1,11 +1,21 @@
-"""
-Deep Research Assistant Agent
+"""agent.py
 
-A Deep Agents-powered research assistant that demonstrates CopilotKit's
-planning, filesystem, and subagent capabilities using Tavily for web research.
+Builds the Deep Agents LangGraph for this demo.
+
+This project supports two modes, selected via the AGENT_MODE env var:
+
+- research (default): research assistant behavior
+- coding: coding agent behavior with shell/filesystem tools enabled
+
+Notes:
+- The Deep Agents SDK provides a standard set of built-in tools (e.g. read_file,
+  write_file, edit_file, list_directory, execute_command, write_todos). In coding
+  mode, we rely on those built-ins and keep the custom `research` tool available
+  as an optional capability.
 """
 
 import os
+
 from dotenv import load_dotenv
 from langchain_openai import ChatOpenAI
 from deepagents import create_deep_agent
@@ -17,8 +27,7 @@ from tools import research
 load_dotenv()
 
 
-# Main agent system prompt - coordinates research and synthesizes findings
-MAIN_SYSTEM_PROMPT = """You are a Deep Research Assistant, an expert at planning and
+RESEARCH_SYSTEM_PROMPT = """You are a Deep Research Assistant, an expert at planning and
 executing comprehensive research on any topic.
 
 Hard rules (ALWAYS follow):
@@ -47,23 +56,46 @@ Example workflow:
 Always maintain a professional, comprehensive research style."""
 
 
+CODING_SYSTEM_PROMPT = """You are Deep Agents IDE, a senior software engineer operating inside a coding workspace.
+
+Hard rules (ALWAYS follow):
+- NEVER output raw JSON, data structures, or code blocks in your messages
+- Communicate with the user only in natural, readable prose
+- Prefer making changes by reading relevant files, then writing minimal diffs
+
+Your workflow:
+1. PLAN: Create actionable todos using write_todos
+2. INSPECT: Use list_directory and read_file to understand the codebase
+3. IMPLEMENT: Use write_file / edit_file to make changes
+4. VERIFY: Use execute_command to run format/lint/tests where available
+5. REPORT: Summarize what changed and what to do next
+
+Guidelines:
+- Use execute_command for git/status/grep/tests when helpful
+- Keep changes small and focused; don't refactor unrelated code
+- Keep the research tool available for quick lookups, but prioritize local code inspection
+"""
+
+
+def _get_agent_mode() -> str:
+    mode = (os.environ.get("AGENT_MODE") or "research").strip().lower()
+    return "coding" if mode == "coding" else "research"
+
+
 def build_agent():
-    """Build the Deep Research Agent with CopilotKit integration.
+    """Build the Deep Agent with CopilotKit integration."""
 
-    Creates a main research coordinator agent with a researcher subagent.
-    Uses CopilotKitMiddleware for frontend state sync and generative UI.
-
-    Returns:
-        Compiled LangGraph StateGraph configured for research tasks
-    """
     api_key = os.environ.get("OPENAI_API_KEY")
     if not api_key:
         raise RuntimeError("Missing OPENAI_API_KEY environment variable")
 
-    # Check for Tavily API key
-    tavily_key = os.environ.get("TAVILY_API_KEY")
-    if not tavily_key:
-        raise RuntimeError("Missing TAVILY_API_KEY environment variable")
+    mode = _get_agent_mode()
+
+    # Tavily is only required for research mode.
+    if mode == "research":
+        tavily_key = os.environ.get("TAVILY_API_KEY")
+        if not tavily_key:
+            raise RuntimeError("Missing TAVILY_API_KEY environment variable")
 
     # Initialize LLM - use model from env or default to gpt-5.2
     model_name = os.environ.get("OPENAI_MODEL", "gpt-5.2")
@@ -73,24 +105,21 @@ def build_agent():
         api_key=api_key,
     )
 
-    # Main agent gets research tool plus built-in Deep Agents tools
-    # (write_todos, read_file, write_file)
-    # The research tool wraps an internal Deep Agent that runs via .invoke()
-    # so its text doesn't stream to the frontend
+    # Custom tools. Deep Agents will add its built-in tools automatically.
+    # Keep research() available in both modes.
     main_tools = [research]
 
-    # Create the Deep Agent with CopilotKit middleware
-    # No subagents - research() tool handles web search internally
+    system_prompt = CODING_SYSTEM_PROMPT if mode == "coding" else RESEARCH_SYSTEM_PROMPT
+
     agent_graph = create_deep_agent(
         model=llm,
-        system_prompt=MAIN_SYSTEM_PROMPT,
+        system_prompt=system_prompt,
         tools=main_tools,
         middleware=[CopilotKitMiddleware()],
         checkpointer=MemorySaver(),
     )
 
-    print(f"[AGENT] Deep Research Agent created with model={model_name}")
+    print(f"[AGENT] Agent created with mode={mode}, model={model_name}")
     print(f"[AGENT] Main tools: {[t.name for t in main_tools]}")
 
-    # Configure recursion limit for complex research tasks
     return agent_graph.with_config({"recursion_limit": 100})

--- a/agent/main.py
+++ b/agent/main.py
@@ -1,11 +1,19 @@
-"""
-Deep Research Assistant - FastAPI Server
+"""main.py
 
-Serves the Deep Research Agent via AG-UI protocol for CopilotKit integration.
-The agent uses Tavily for web research and Deep Agents for planning and filesystem operations.
+FastAPI server for the demo agent.
+
+This server exposes an AG-UI endpoint used by the Next.js frontend.
+The agent supports multiple modes via AGENT_MODE:
+
+- research (default)
+- coding
+
+Tool-call emission is configured per-mode to avoid leaking internal subagent
+noise into the chat UI.
 """
 
 import os
+
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from dotenv import load_dotenv
@@ -18,13 +26,12 @@ from agent import build_agent
 load_dotenv()
 
 app = FastAPI(
-    title="Deep Research Assistant",
-    description="A research assistant powered by Deep Agents and CopilotKit",
+    title="Deep Agents Demo",
+    description="A demo agent powered by Deep Agents and CopilotKit",
     version="1.0.0",
 )
 
 # Enable CORS for frontend communication
-# Using "*" for demo purposes - allows any origin including localhost and Railway deployments
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -36,50 +43,68 @@ app.add_middleware(
 
 @app.get("/health")
 def health():
-    """Health check endpoint for monitoring and Railway deployments"""
-    return {"status": "ok", "service": "deep-research-agent", "version": "1.0.0"}
+    return {
+        "status": "ok",
+        "service": "deep-agents-demo-agent",
+        "version": "1.0.0",
+        "mode": (os.environ.get("AGENT_MODE") or "research"),
+    }
 
 
-# Build and register the Deep Research Agent
+def _agent_mode() -> str:
+    mode = (os.environ.get("AGENT_MODE") or "research").strip().lower()
+    return "coding" if mode == "coding" else "research"
+
+
+# Build and register the agent
 try:
     agent_graph = build_agent()
 
-    # Configure which tool calls to emit to the frontend
-    # Only emit main agent tools - suppress internal tools (internet_search from research subagent)
-    # This prevents subagent tool calls from appearing as JSON noise in the chat
-    agui_config = copilotkit_customize_config(
-        emit_tool_calls=[
+    mode = _agent_mode()
+
+    # Configure which tool calls to emit to the frontend.
+    # In research mode, suppress internal subagent noise (internet_search).
+    # In coding mode, emit the core workspace tools.
+    if mode == "coding":
+        emit_tool_calls = [
+            "execute_command",
+            "list_directory",
+            "read_file",
+            "write_file",
+            "edit_file",
+            "write_todos",
+            "research",
+        ]
+    else:
+        emit_tool_calls = [
             "research",
             "write_todos",
             "write_file",
             "read_file",
             "edit_file",
         ]
-    )
 
-    # Add recursion limit for complex research tasks (6+ research calls + file operations)
+    agui_config = copilotkit_customize_config(emit_tool_calls=emit_tool_calls)
     agui_config["recursion_limit"] = 100
 
-    # Add AG-UI endpoint at root path for CopilotKit frontend
     add_langgraph_fastapi_endpoint(
         app=app,
         agent=LangGraphAGUIAgent(
-            name="research_assistant",
-            description="A deep research assistant that plans, searches, and synthesizes research reports",
+            name="deep_agents_demo",
+            description="A demo agent that can run in research or coding mode",
             graph=agent_graph,
             config=agui_config,
         ),
         path="/",
     )
 
-    print("[SERVER] Deep Research Agent registered at /")
+    print(f"[SERVER] Agent registered at / (mode={mode})")
 except Exception as e:
     print(f"[ERROR] Failed to build agent: {e}")
     raise
 
 
 def main():
-    """Run the server with uvicorn"""
     import uvicorn
 
     host = os.getenv("SERVER_HOST", "0.0.0.0")


### PR DESCRIPTION
Closes #1\n\nAdds AGENT_MODE (default: research) and switches system prompt + emitted tool calls based on mode. Research mode still uses Tavily-backed research tool; coding mode enables emitting filesystem/shell tools and relaxes Tavily requirement.