### PR TITLE
Add GitHub panel to workspace

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,15 @@ import { useDefaultTool } from "@copilotkit/react-core";
 import { Workspace } from "@/components/Workspace";
 import { ResearchState, INITIAL_STATE, Todo } from "@/types/research";
 import { ToolCard } from "@/components/ToolCard";
+import type { GitHubIssue, GitHubPullRequest } from "@/types/github";
+
+function safeJsonParse(text: string): unknown {
+  try {
+    return JSON.parse(text);
+  } catch {
+    return null;
+  }
+}
 
 export default function Page() {
   const [state, setState] = useState<ResearchState>(INITIAL_STATE);
@@ -28,37 +37,106 @@ export default function Page() {
 
       // Handle research tool - track summary and sources
       if (name === "research" && status === "complete" && result) {
-        const researchResult = result as { summary: string; sources: Array<{url: string, title: string, content?: string, status: "found" | "scraped" | "failed"}> };
+        const researchResult = result as {
+          summary: string;
+          sources: Array<{
+            url: string;
+            title: string;
+            content?: string;
+            status: "found" | "scraped" | "failed";
+          }>;
+        };
 
         // Track sources in state
         if (researchResult.sources && researchResult.sources.length > 0) {
-          queueMicrotask(() => setState(prev => ({
-            ...prev,
-            sources: [...prev.sources, ...researchResult.sources]
-          })));
+          queueMicrotask(() =>
+            setState((prev) => ({
+              ...prev,
+              sources: [...prev.sources, ...researchResult.sources],
+            }))
+          );
         }
 
-        console.log(`[UI] Research completed: ${researchResult.sources?.length || 0} sources found`);
+        console.log(
+          `[UI] Research completed: ${researchResult.sources?.length || 0} sources found`
+        );
       }
 
       // Handle write_todos tool
       if (name === "write_todos" && status === "complete" && args?.todos) {
-        const todosWithIds = (args.todos as Array<{ id?: string; content: string; status: string }>).map(
-          (todo, index) => ({
-            ...todo,
-            id: todo.id || `todo-${Date.now()}-${index}`,
-          })
-        );
-        queueMicrotask(() => setState(prev => ({ ...prev, todos: todosWithIds as Todo[] })));
+        const todosWithIds = (
+          args.todos as Array<{ id?: string; content: string; status: string }>
+        ).map((todo, index) => ({
+          ...todo,
+          id: todo.id || `todo-${Date.now()}-${index}`,
+        }));
+        queueMicrotask(() => setState((prev) => ({ ...prev, todos: todosWithIds as Todo[] })));
       }
 
       // Handle write_file tool
       // Deep Agents uses file_path (not path) as the parameter name
       if (name === "write_file" && status === "complete" && args?.file_path) {
-        queueMicrotask(() => setState(prev => ({
-          ...prev,
-          files: [...prev.files, { path: args.file_path as string, content: args.content as string, createdAt: new Date().toISOString() }]
-        })));
+        queueMicrotask(() =>
+          setState((prev) => ({
+            ...prev,
+            files: [
+              ...prev.files,
+              {
+                path: args.file_path as string,
+                content: args.content as string,
+                createdAt: new Date().toISOString(),
+              },
+            ],
+          }))
+        );
+      }
+
+      // Capture gh issue/pr list JSON from execute_command results.
+      // We keep it lightweight: if stdout parses to an array and the command matches,
+      // stash it under state.github.
+      if (name === "execute_command" && status === "complete" && result) {
+        const command = (args.command as string) || "";
+        const stdout = (result as { stdout?: string })?.stdout;
+
+        if (typeof stdout === "string" && stdout.trim().length > 0) {
+          const parsed = safeJsonParse(stdout);
+
+          if (command.includes("gh issue list") && Array.isArray(parsed)) {
+            queueMicrotask(() =>
+              setState((prev) => ({
+                ...prev,
+                github: {
+                  ...(prev as any).github,
+                  issues: parsed as GitHubIssue[],
+                  pullRequests: ((prev as any).github?.pullRequests || []) as GitHubPullRequest[],
+                  context: {
+                    repo: ((prev as any).github?.context?.repo as string | undefined) ||
+                      (command.match(/--repo\s+([^\s]+)/)?.[1] as string | undefined),
+                    branch: (prev as any).github?.context?.branch,
+                  },
+                },
+              }))
+            );
+          }
+
+          if (command.includes("gh pr list") && Array.isArray(parsed)) {
+            queueMicrotask(() =>
+              setState((prev) => ({
+                ...prev,
+                github: {
+                  ...(prev as any).github,
+                  pullRequests: parsed as GitHubPullRequest[],
+                  issues: ((prev as any).github?.issues || []) as GitHubIssue[],
+                  context: {
+                    repo: ((prev as any).github?.context?.repo as string | undefined) ||
+                      (command.match(/--repo\s+([^\s]+)/)?.[1] as string | undefined),
+                    branch: (prev as any).github?.context?.branch,
+                  },
+                },
+              }))
+            );
+          }
+        }
       }
 
       return <ToolCard {...props} />;
@@ -67,58 +145,63 @@ export default function Page() {
 
   return (
     <div className="relative min-h-screen">
-        {/* Animated background */}
-        <div className="abstract-bg">
-          <div className="blob-3" />
-        </div>
+      {/* Animated background */}
+      <div className="abstract-bg">
+        <div className="blob-3" />
+      </div>
 
-        {/* Main content */}
-        <main className="relative z-10 h-screen flex overflow-hidden">
-          {/* Chat panel - left side (38%) */}
-          <div className="w-[38%] h-full border-r border-[var(--color-border-glass)] bg-[var(--color-glass-dark)] backdrop-blur-xl overflow-hidden">
-            <div className="h-full flex flex-col">
-              {/* Header */}
-              <header style={{ padding: 'var(--space-8)' }} className="border-b border-[var(--color-border-glass)]">
-                <h1
-                  style={{
-                    fontSize: 'var(--text-3xl)',
-                    fontWeight: 'var(--font-extrabold)',
-                    fontFamily: 'var(--font-display)',
-                    fontOpticalSizing: 'auto'
-                  }}
-                  className="text-gradient"
-                >
-                  Deep Research Assistant
-                </h1>
-                <p
-                  style={{
-                    fontSize: 'var(--text-sm)',
-                    color: 'var(--color-text-secondary)',
-                    marginTop: 'var(--space-1)'
-                  }}
-                >
-                  Ask me to research any topic
-                </p>
-              </header>
+      {/* Main content */}
+      <main className="relative z-10 h-screen flex overflow-hidden">
+        {/* Chat panel - left side (38%) */}
+        <div className="w-[38%] h-full border-r border-[var(--color-border-glass)] bg-[var(--color-glass-dark)] backdrop-blur-xl overflow-hidden">
+          <div className="h-full flex flex-col">
+            {/* Header */}
+            <header
+              style={{ padding: "var(--space-8)" }}
+              className="border-b border-[var(--color-border-glass)]"
+            >
+              <h1
+                style={{
+                  fontSize: "var(--text-3xl)",
+                  fontWeight: "var(--font-extrabold)",
+                  fontFamily: "var(--font-display)",
+                  fontOpticalSizing: "auto",
+                }}
+                className="text-gradient"
+              >
+                Deep Research Assistant
+              </h1>
+              <p
+                style={{
+                  fontSize: "var(--text-sm)",
+                  color: "var(--color-text-secondary)",
+                  marginTop: "var(--space-1)",
+                }}
+              >
+                Ask me to research any topic
+              </p>
+            </header>
 
-              <div style={{ flex: 1, minHeight: 0, overflow: 'hidden', padding: 'var(--space-6)' }}>
-                <CopilotChat
-                  className="h-full"
-                  labels={{
-                    title: "Deep Research Assistant",
-                    initial: "What topic would you like me to research?",
-                    placeholder: "Ask me to research any topic...",
-                  }}
-                />
-              </div>
+            <div
+              style={{ flex: 1, minHeight: 0, overflow: "hidden", padding: "var(--space-6)" }}
+            >
+              <CopilotChat
+                className="h-full"
+                labels={{
+                  title: "Deep Research Assistant",
+                  initial: "What topic would you like me to research?",
+                  placeholder: "Ask me to research any topic...",
+                }}
+              />
             </div>
           </div>
+        </div>
 
-          {/* Workspace panel - right side (62%) */}
-          <div className="w-[62%] h-full overflow-hidden">
-            <Workspace state={state} />
-          </div>
-        </main>
+        {/* Workspace panel - right side (62%) */}
+        <div className="w-[62%] h-full overflow-hidden">
+          <Workspace state={state} />
+        </div>
+      </main>
     </div>
   );
 }

--- a/src/components/GitHubPanel.tsx
+++ b/src/components/GitHubPanel.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import React from "react";
+import type { GitHubState, GitHubIssue } from "@/types/github";
+
+export function GitHubPanel({
+  github,
+  onAssignIssue,
+}: {
+  github: GitHubState;
+  onAssignIssue?: (issue: GitHubIssue) => void;
+}) {
+  return (
+    <div className="workspace-section-content">
+      <div className="mb-3">
+        <div className="flex items-center justify-between">
+          <div>
+            <div className="text-sm font-semibold text-[var(--color-text-primary)]">Repository</div>
+            <div className="text-xs text-[var(--color-text-tertiary)]">
+              {(github.context?.repo || "Unknown repo") +
+                (github.context?.branch ? ` • ${github.context.branch}` : "")}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="mb-4">
+        <div className="text-xs font-semibold text-[var(--color-text-tertiary)] mb-2">
+          Open issues ({github.issues.length})
+        </div>
+        <div className="space-y-2">
+          {github.issues.length === 0 ? (
+            <div className="text-xs text-[var(--color-text-tertiary)]">No issues found</div>
+          ) : (
+            github.issues.map((issue) => (
+              <div
+                key={issue.number}
+                className="file-item"
+                style={{ padding: "var(--space-3)" }}
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="text-sm text-[var(--color-text-primary)] truncate">
+                      #{issue.number} {issue.title}
+                    </div>
+                    <div className="text-xs text-[var(--color-text-tertiary)] mt-1">
+                      {(issue.assignees?.length ?? 0) > 0
+                        ? `Assignee: ${issue.assignees?.[0]?.login}`
+                        : "Unassigned"}
+                    </div>
+                  </div>
+
+                  <button
+                    className="text-xs px-2 py-1 rounded-md border border-[var(--color-border)] hover:bg-[var(--color-glass-subtle)] transition-colors"
+                    onClick={() => onAssignIssue?.(issue)}
+                    disabled={!onAssignIssue}
+                    title={onAssignIssue ? "Assign to agent" : "Not available"}
+                  >
+                    Assign to Agent
+                  </button>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+
+      <div>
+        <div className="text-xs font-semibold text-[var(--color-text-tertiary)] mb-2">
+          Open PRs ({github.pullRequests.length})
+        </div>
+        <div className="space-y-2">
+          {github.pullRequests.length === 0 ? (
+            <div className="text-xs text-[var(--color-text-tertiary)]">No PRs found</div>
+          ) : (
+            github.pullRequests.map((pr) => (
+              <div
+                key={pr.number}
+                className="file-item"
+                style={{ padding: "var(--space-3)" }}
+              >
+                <div className="text-sm text-[var(--color-text-primary)] truncate">
+                  #{pr.number} {pr.title}
+                </div>
+                <div className="text-xs text-[var(--color-text-tertiary)] mt-1">
+                  {(pr.isDraft ? "Draft" : pr.state || "OPEN") +
+                    (pr.headRefName ? ` • ${pr.headRefName}` : "")}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Workspace.tsx
+++ b/src/components/Workspace.tsx
@@ -1,9 +1,22 @@
 "use client";
 
-import { useState } from "react";
-import { ChevronDown, ChevronRight, ListTodo, FileText, Download, Globe, Check, Circle, CircleDot, X } from "lucide-react";
+import { useMemo, useState } from "react";
+import {
+  ChevronDown,
+  ChevronRight,
+  ListTodo,
+  FileText,
+  Download,
+  Globe,
+  Check,
+  Circle,
+  CircleDot,
+  X,
+  Github,
+} from "lucide-react";
 import { ResearchState, Todo, ResearchFile, Source } from "@/types/research";
 import { FileViewerModal } from "@/components/FileViewerModal";
+import { GitHubPanel } from "@/components/GitHubPanel";
 
 // Helper function to download file content
 function downloadFile(file: ResearchFile) {
@@ -21,6 +34,8 @@ function downloadFile(file: ResearchFile) {
 interface WorkspaceProps {
   state: ResearchState;
 }
+
+type WorkspaceTab = "workspace" | "github";
 
 // Collapsible section component with smooth transitions
 function Section({
@@ -50,12 +65,12 @@ function Section({
           {badge !== undefined && badge > 0 && (
             <span
               style={{
-                background: 'var(--color-accent)',
-                color: 'var(--color-background)',
-                padding: 'var(--space-1) var(--space-2)',
-                fontSize: 'var(--text-xs)',
-                fontWeight: 'var(--font-semibold)',
-                borderRadius: 'var(--radius-lg)'
+                background: "var(--color-accent)",
+                color: "var(--color-background)",
+                padding: "var(--space-1) var(--space-2)",
+                fontSize: "var(--text-xs)",
+                fontWeight: "var(--font-semibold)",
+                borderRadius: "var(--radius-lg)",
               }}
             >
               {badge}
@@ -77,16 +92,23 @@ function Section({
 function TodoList({ todos }: { todos: Todo[] }) {
   if (todos.length === 0) {
     return (
-      <div className="empty-state" style={{ paddingTop: 'var(--space-8)', paddingBottom: 'var(--space-8)', animation: 'fadeIn 0.4s ease' }}>
+      <div
+        className="empty-state"
+        style={{
+          paddingTop: "var(--space-8)",
+          paddingBottom: "var(--space-8)",
+          animation: "fadeIn 0.4s ease",
+        }}
+      >
         <ListTodo
           size={32}
           strokeWidth={1.5}
           style={{
-            color: 'var(--color-text-tertiary)',
-            marginBottom: 'var(--space-3)'
+            color: "var(--color-text-tertiary)",
+            marginBottom: "var(--space-3)",
           }}
         />
-        <p style={{ fontSize: 'var(--text-sm)' }}>No tasks yet</p>
+        <p style={{ fontSize: "var(--text-sm)" }}>No tasks yet</p>
         <p className="text-xs mt-1">Research tasks will appear here</p>
       </div>
     );
@@ -101,8 +123,8 @@ function TodoList({ todos }: { todos: Todo[] }) {
             todo.status === "completed"
               ? "todo-item-completed"
               : todo.status === "in_progress"
-              ? "todo-item-inprogress"
-              : "todo-item-pending"
+                ? "todo-item-inprogress"
+                : "todo-item-pending"
           }`}
         >
           <span
@@ -110,8 +132,8 @@ function TodoList({ todos }: { todos: Todo[] }) {
               todo.status === "completed"
                 ? "status-completed"
                 : todo.status === "in_progress"
-                ? "status-inprogress"
-                : "status-pending"
+                  ? "status-inprogress"
+                  : "status-pending"
             }`}
           >
             {todo.status === "completed" ? (
@@ -139,16 +161,23 @@ function FileList({
 }) {
   if (files.length === 0) {
     return (
-      <div className="empty-state" style={{ paddingTop: 'var(--space-8)', paddingBottom: 'var(--space-8)', animation: 'fadeIn 0.4s ease' }}>
+      <div
+        className="empty-state"
+        style={{
+          paddingTop: "var(--space-8)",
+          paddingBottom: "var(--space-8)",
+          animation: "fadeIn 0.4s ease",
+        }}
+      >
         <FileText
           size={32}
           strokeWidth={1.5}
           style={{
-            color: 'var(--color-text-tertiary)',
-            marginBottom: 'var(--space-3)'
+            color: "var(--color-text-tertiary)",
+            marginBottom: "var(--space-3)",
           }}
         />
-        <p style={{ fontSize: 'var(--text-sm)' }}>No files yet</p>
+        <p style={{ fontSize: "var(--text-sm)" }}>No files yet</p>
         <p className="text-xs mt-1">Research artifacts will appear here</p>
       </div>
     );
@@ -194,16 +223,23 @@ function FileList({
 function SourceList({ sources }: { sources: Source[] }) {
   if (sources.length === 0) {
     return (
-      <div className="empty-state" style={{ paddingTop: 'var(--space-8)', paddingBottom: 'var(--space-8)', animation: 'fadeIn 0.4s ease' }}>
+      <div
+        className="empty-state"
+        style={{
+          paddingTop: "var(--space-8)",
+          paddingBottom: "var(--space-8)",
+          animation: "fadeIn 0.4s ease",
+        }}
+      >
         <Globe
           size={32}
           strokeWidth={1.5}
           style={{
-            color: 'var(--color-text-tertiary)',
-            marginBottom: 'var(--space-3)'
+            color: "var(--color-text-tertiary)",
+            marginBottom: "var(--space-3)",
           }}
         />
-        <p style={{ fontSize: 'var(--text-sm)' }}>No sources yet</p>
+        <p style={{ fontSize: "var(--text-sm)" }}>No sources yet</p>
         <p className="text-xs mt-1">Web sources will appear here</p>
       </div>
     );
@@ -214,7 +250,9 @@ function SourceList({ sources }: { sources: Source[] }) {
       {sources.map((source, i) => (
         <div
           key={`${source.url}-${i}`}
-          className={`file-item animate-fadeSlideIn ${source.status === "failed" ? "source-failed" : ""}`}
+          className={`file-item animate-fadeSlideIn ${
+            source.status === "failed" ? "source-failed" : ""
+          }`}
           title={source.status === "failed" ? "Failed to scrape this source" : undefined}
         >
           <div className="flex items-center gap-3">
@@ -223,28 +261,29 @@ function SourceList({ sources }: { sources: Source[] }) {
                 source.status === "scraped"
                   ? "status-completed"
                   : source.status === "failed"
-                  ? ""
-                  : "status-pending"
+                    ? ""
+                    : "status-pending"
               }`}
-              style={source.status === "failed" ? { color: 'var(--color-error)' } : undefined}
+              style={source.status === "failed" ? { color: "var(--color-error)" } : undefined}
             >
               {source.status === "scraped" ? (
-                <Check size={14} style={{ color: 'var(--color-success)' }} />
+                <Check size={14} style={{ color: "var(--color-success)" }} />
               ) : source.status === "failed" ? (
-                <X size={14} style={{ color: 'var(--color-error)' }} />
+                <X size={14} style={{ color: "var(--color-error)" }} />
               ) : (
                 <Circle size={14} />
               )}
             </span>
             <div className="flex-1 min-w-0">
               <p className="text-sm font-medium text-[var(--color-text-primary)] truncate">
-                {source.title || (() => {
-                  try {
-                    return new URL(source.url).hostname;
-                  } catch {
-                    return source.url.slice(0, 40);
-                  }
-                })()}
+                {source.title ||
+                  (() => {
+                    try {
+                      return new URL(source.url).hostname;
+                    } catch {
+                      return source.url.slice(0, 40);
+                    }
+                  })()}
               </p>
               <a
                 href={source.url}
@@ -264,10 +303,17 @@ function SourceList({ sources }: { sources: Source[] }) {
 
 // Main Workspace component
 export function Workspace({ state }: WorkspaceProps) {
-  const { todos, files, sources } = state;
+  const { todos, files, sources, github } = state;
   const fileCount = files.length;
   const todoCount = todos.length;
   const sourceCount = sources.length;
+
+  const [activeTab, setActiveTab] = useState<WorkspaceTab>("workspace");
+
+  const githubBadge = useMemo(
+    () => (github.issues.length || 0) + (github.pullRequests.length || 0),
+    [github]
+  );
 
   // State for file viewer modal
   const [selectedFile, setSelectedFile] = useState<ResearchFile | null>(null);
@@ -276,22 +322,61 @@ export function Workspace({ state }: WorkspaceProps) {
     <div className="workspace-panel p-6">
       <div className="mb-6">
         <h2 className="text-xl font-bold text-[var(--color-text-primary)]">Workspace</h2>
-        <p className="text-sm text-[var(--color-text-secondary)]">
-          Research progress and artifacts
-        </p>
+        <p className="text-sm text-[var(--color-text-secondary)]">Research progress and artifacts</p>
       </div>
 
-      <Section title="Research Plan" icon={ListTodo} badge={todoCount}>
-        <TodoList todos={todos} />
-      </Section>
+      {/* Tabs */}
+      <div className="flex items-center gap-2 mb-4">
+        <button
+          className={`text-sm px-3 py-1.5 rounded-md border transition-colors ${
+            activeTab === "workspace"
+              ? "bg-[var(--color-glass-subtle)] border-[var(--color-border)] text-[var(--color-text-primary)]"
+              : "border-transparent text-[var(--color-text-tertiary)] hover:text-[var(--color-text-secondary)]"
+          }`}
+          onClick={() => setActiveTab("workspace")}
+        >
+          Workspace
+        </button>
+        <button
+          className={`text-sm px-3 py-1.5 rounded-md border transition-colors flex items-center gap-2 ${
+            activeTab === "github"
+              ? "bg-[var(--color-glass-subtle)] border-[var(--color-border)] text-[var(--color-text-primary)]"
+              : "border-transparent text-[var(--color-text-tertiary)] hover:text-[var(--color-text-secondary)]"
+          }`}
+          onClick={() => setActiveTab("github")}
+        >
+          <Github className="w-4 h-4" /> GitHub
+          {githubBadge > 0 && (
+            <span className="text-xs px-2 py-0.5 rounded-full bg-[var(--color-accent)] text-[var(--color-background)]">
+              {githubBadge}
+            </span>
+          )}
+        </button>
+      </div>
 
-      <Section title="Files" icon={FileText} badge={fileCount}>
-        <FileList files={files} onFileClick={setSelectedFile} />
-      </Section>
+      {activeTab === "github" ? (
+        <GitHubPanel
+          github={github}
+          onAssignIssue={(issue) => {
+            // Lightweight stub: log for now; backend agent can later listen for this intent.
+            console.log(`[UI] Assign to Agent clicked for issue #${issue.number}`);
+          }}
+        />
+      ) : (
+        <>
+          <Section title="Research Plan" icon={ListTodo} badge={todoCount}>
+            <TodoList todos={todos} />
+          </Section>
 
-      <Section title="Sources" icon={Globe} badge={sourceCount}>
-        <SourceList sources={sources} />
-      </Section>
+          <Section title="Files" icon={FileText} badge={fileCount}>
+            <FileList files={files} onFileClick={setSelectedFile} />
+          </Section>
+
+          <Section title="Sources" icon={Globe} badge={sourceCount}>
+            <SourceList sources={sources} />
+          </Section>
+        </>
+      )}
 
       {/* File Viewer Modal */}
       <FileViewerModal file={selectedFile} onClose={() => setSelectedFile(null)} />

--- a/src/types/github.ts
+++ b/src/types/github.ts
@@ -1,0 +1,30 @@
+export interface GitHubIssue {
+  number: number;
+  title: string;
+  url?: string;
+  state?: string;
+  labels?: Array<{ name: string }>;
+  assignees?: Array<{ login: string }>;
+}
+
+export interface GitHubPullRequest {
+  number: number;
+  title: string;
+  url?: string;
+  state?: string;
+  isDraft?: boolean;
+  mergeable?: string;
+  headRefName?: string;
+  baseRefName?: string;
+}
+
+export interface GitHubRepoContext {
+  repo?: string;
+  branch?: string;
+}
+
+export interface GitHubState {
+  context?: GitHubRepoContext;
+  issues: GitHubIssue[];
+  pullRequests: GitHubPullRequest[];
+}

--- a/src/types/research.ts
+++ b/src/types/research.ts
@@ -6,6 +6,8 @@
  * to avoid type mismatches with Python FilesystemMiddleware.
  */
 
+import type { GitHubState } from "@/types/github";
+
 export interface Todo {
   id: string;
   content: string;
@@ -30,10 +32,16 @@ export interface ResearchState {
   todos: Todo[];
   files: ResearchFile[];
   sources: Source[];
+  github: GitHubState;
 }
 
 export const INITIAL_STATE: ResearchState = {
   todos: [],
   files: [],
   sources: [],
+  github: {
+    context: {},
+    issues: [],
+    pullRequests: [],
+  },
 };


### PR DESCRIPTION
Closes #5\n\nAdds a GitHub tab in the workspace UI that displays repo context, open issues, and open PRs. The panel populates reactively by parsing JSON stdout from `execute_command` tool calls that run `gh issue list` / `gh pr list`. Includes an 'Assign to Agent' button stub for future automation.